### PR TITLE
Fix OAuth tokens never getting updated

### DIFF
--- a/panel/src/pages/api/auth/[...nextauth].ts
+++ b/panel/src/pages/api/auth/[...nextauth].ts
@@ -15,6 +15,20 @@ export const authOptions: NextAuthOptions = {
       }
       return session;
     },
+    async signIn({ account }) {
+      if (account) {
+        await prisma.account.update({
+          where: {
+            provider_providerAccountId: {
+              provider: account.provider,
+              providerAccountId: account.providerAccountId,
+            }
+          },
+          data: account,
+        })
+      }
+      return true;
+    }
   },
   // Configure one or more authentication providers
   adapter: PrismaAdapter(prisma),

--- a/panel/src/pages/api/checkAccess.ts
+++ b/panel/src/pages/api/checkAccess.ts
@@ -1,5 +1,6 @@
 import { type NextApiRequest, type NextApiResponse } from "next";
 import { prisma } from "../../server/db/client";
+import { env } from "../../env/server.mjs";
 
 type TwitchSubSuccess = {
   data: Array<{
@@ -136,7 +137,7 @@ const checkAccess = async (req: NextApiRequest, res: NextApiResponse) => {
     return res.send({
       access: false,
       error: "TOKEN_ERROR",
-      description: `There was an error with your account - please go to ${process.env.NEXTAUTH_URL} and log in again.`,
+      description: `There was an error with your account - please go to ${env.NEXTAUTH_URL} and log in again.`,
     });
   }
 
@@ -158,8 +159,8 @@ const checkAccess = async (req: NextApiRequest, res: NextApiResponse) => {
       body: new URLSearchParams({
         grant_type: "refresh_token",
         refresh_token: userAccount.refresh_token,
-        client_id: process.env.TWITCH_CLIENT_ID!,
-        client_secret: process.env.TWITCH_CLIENT_SECRET!,
+        client_id: env.TWITCH_CLIENT_ID,
+        client_secret: env.TWITCH_CLIENT_SECRET,
       }),
     });
 
@@ -170,7 +171,7 @@ const checkAccess = async (req: NextApiRequest, res: NextApiResponse) => {
       return res.send({
         access: false,
         error: "REFRESH_ERROR",
-        description: `There was an error when trying to refresh your Twitch token - please go to ${process.env.NEXTAUTH_URL} and log in again`,
+        description: `There was an error when trying to refresh your Twitch token - please go to ${env.NEXTAUTH_URL} and log in again`,
       });
     }
 
@@ -195,7 +196,7 @@ const checkAccess = async (req: NextApiRequest, res: NextApiResponse) => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       headers: {
-        "Client-ID": process.env.TWITCH_CLIENT_ID,
+        "Client-ID": env.TWITCH_CLIENT_ID,
         Authorization: `Bearer ${userAccount?.access_token}`,
       },
     }

--- a/panel/src/pages/api/checkAccess.ts
+++ b/panel/src/pages/api/checkAccess.ts
@@ -149,24 +149,24 @@ const checkAccess = async (req: NextApiRequest, res: NextApiResponse) => {
   });
 
   // If the token is invalid, refresh it
-  if (valid.status === 401) {
+  if (!valid.ok) {
     const refresh = await fetch("https://id.twitch.tv/oauth2/token", {
       method: "POST",
       headers: {
-        "Content-Type": "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
       },
-      body: JSON.stringify({
+      body: new URLSearchParams({
         grant_type: "refresh_token",
         refresh_token: userAccount.refresh_token,
-        client_id: process.env.TWITCH_CLIENT_ID,
-        client_secret: process.env.TWITCH_CLIENT_SECRET,
+        client_id: process.env.TWITCH_CLIENT_ID!,
+        client_secret: process.env.TWITCH_CLIENT_SECRET!,
       }),
     });
 
     const refreshResponse = await refresh.json();
 
     // If the refresh token is invalid, the user needs to re-authenticate
-    if ("error" in refreshResponse) {
+    if (!refresh.ok) {
       return res.send({
         access: false,
         error: "REFRESH_ERROR",


### PR DESCRIPTION
So next-auth has... a few bugs, and some interesting decisions, and as a result it appears that it just *never* updates account details by default. I can see in my dev environment that when I sign in, it's not attempting to update the user or account tables at all, just querying them. This means that after the account is created, the twitch OAuth credentials are set in stone - no matter what the user does, the access and refresh tokens will never change without our code doing it.

Our code does attempt to refresh tokens whenever the server makes a checkAccess request, but this was a) slightly buggy and b) not able to function if the refresh token was itself invalid. From the Twitch API docs:

> Yes, refresh tokens can become invalid. Refresh tokens, like access tokens, can become invalid if the user changes their password or disconnects your app.

The next-auth docs (and github issues) are kind of unclear whether this is intended behaviour or not - but either way, we can work around it a bit, because next-auth *is* making a request to `/oauth2/token`, it's just not saving the response back to the database.

I've fixed it here by hooking the signIn callback and manually updating the account database with the new tokens.

Additionally I've fixed up the refreshing logic a bit - it was previously ignoring errors when refreshing the token and dropping through to make the "are we subscribed" request anyway.

FWIW I also need to update the plugin to show custom error messages from the server, such as the one returned in the "refresh error" response. It might not be a bad idea to have the server send an error message on *any* error condition (for example, on the `access: false, linked: true` response) rather than hard-coding some strings in the plugin.