### PR TITLE
Floodgate account linking support & error improvements

### DIFF
--- a/panel/src/pages/api/checkAccess.ts
+++ b/panel/src/pages/api/checkAccess.ts
@@ -207,7 +207,7 @@ const checkAccess = async (req: NextApiRequest, res: NextApiResponse) => {
     res.send({
       access: false,
       linked: true,
-      description: `You don't have an active subscription to the streamer that owns this server! Please renew your subscription, or visit https://twitchmc.io if you need to link a different account.`,
+      description: `You don't have an active subscription to the streamer that owns this server! Please renew your subscription, or visit ${rootUrl} if you need to link a different account.`,
     });
     return;
   }

--- a/panel/src/pages/api/checkAccess.ts
+++ b/panel/src/pages/api/checkAccess.ts
@@ -2,6 +2,8 @@ import { type NextApiRequest, type NextApiResponse } from "next";
 import { prisma } from "../../server/db/client";
 import { env } from "../../env/server.mjs";
 
+const rootUrl = env.NEXTAUTH_URL;
+
 type TwitchSubSuccess = {
   data: Array<{
     broadcaster_id: string;
@@ -63,7 +65,7 @@ const checkAccess = async (req: NextApiRequest, res: NextApiResponse) => {
   // If the user doesn't already exist
   if (!user) {
     // Check if there is a token in the database
-    const token = await prisma.uUIDVerificationToken.findUnique({
+    let token = await prisma.uUIDVerificationToken.findUnique({
       where: {
         UUID: uuid,
       },
@@ -71,17 +73,11 @@ const checkAccess = async (req: NextApiRequest, res: NextApiResponse) => {
 
     // If not create a new token
     if (!token) {
-      const newToken = await prisma.uUIDVerificationToken.create({
+      token = await prisma.uUIDVerificationToken.create({
         data: {
           UUID: uuid,
           code: Math.random().toString(36).substring(2, 8).toUpperCase(),
         },
-      });
-
-      return res.send({
-        access: false,
-        linked: false,
-        code: newToken.code,
       });
     }
 
@@ -89,6 +85,7 @@ const checkAccess = async (req: NextApiRequest, res: NextApiResponse) => {
       access: false,
       linked: false,
       code: token.code,
+      description: `You need to link your Twitch account in order to play on this server! Please visit ${rootUrl}/connect and use code: ${token.code}`,
     });
   }
 
@@ -137,7 +134,7 @@ const checkAccess = async (req: NextApiRequest, res: NextApiResponse) => {
     return res.send({
       access: false,
       error: "TOKEN_ERROR",
-      description: `There was an error with your account - please go to ${env.NEXTAUTH_URL} and log in again.`,
+      description: `There was an error with your account - please go to ${rootUrl} and log in again.`,
     });
   }
 
@@ -171,7 +168,7 @@ const checkAccess = async (req: NextApiRequest, res: NextApiResponse) => {
       return res.send({
         access: false,
         error: "REFRESH_ERROR",
-        description: `There was an error when trying to refresh your Twitch token - please go to ${env.NEXTAUTH_URL} and log in again`,
+        description: `There was an error when trying to refresh your Twitch token - please go to ${rootUrl} and log in again`,
       });
     }
 
@@ -210,6 +207,7 @@ const checkAccess = async (req: NextApiRequest, res: NextApiResponse) => {
     res.send({
       access: false,
       linked: true,
+      description: `You don't have an active subscription to the streamer that owns this server! Please renew your subscription, or visit https://twitchmc.io if you need to link a different account.`,
     });
     return;
   }

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -23,11 +23,17 @@ repositories {
         name = "jitpack"
         url = "https://jitpack.io"
     }
+
+    maven {
+        name = "GeyserMC"
+        url = uri("https://repo.opencollab.dev/main/")
+    }
 }
 
 dependencies {
     implementation "org.spigotmc:spigot-api:1.18.1-R0.1-SNAPSHOT"
     implementation "com.github.MilkBowl:VaultAPI:1.7.1"
+    compileOnly "org.geysermc.floodgate:api:2.2.5-SNAPSHOT"
 }
 
 processResources {

--- a/plugin/src/main/java/io/twitchmc/PlayerListener.java
+++ b/plugin/src/main/java/io/twitchmc/PlayerListener.java
@@ -1,5 +1,6 @@
 package io.twitchmc;
 
+import io.twitchmc.floodgate.PlayerMap;
 import io.twitchmc.http.ApiClient;
 import io.twitchmc.util.UserCache;
 import net.milkbowl.vault.permission.Permission;
@@ -15,12 +16,14 @@ import java.io.IOException;
 public class PlayerListener implements Listener {
 	private final ApiClient apiClient;
 	private final ConfigHolder configHolder;
+	private final PlayerMap playerMap;
 	private final UserCache userCache;
 	private Permission permissionApi;
 
-	public PlayerListener(ApiClient apiClient, ConfigHolder configHolder) {
+	public PlayerListener(ApiClient apiClient, ConfigHolder configHolder, PlayerMap playerMap) {
 		this.apiClient = apiClient;
 		this.configHolder = configHolder;
+		this.playerMap = playerMap;
 		this.userCache = new UserCache();
 
 		this.permissionApi = Bukkit.getServicesManager().load(Permission.class);
@@ -36,7 +39,17 @@ public class PlayerListener implements Listener {
 
 	@EventHandler
 	public void onPlayerJoin(AsyncPlayerPreLoginEvent event) {
-		var uuid = event.getUniqueId();
+		try {
+			this.tryPlayerJoin(event);
+		} catch (Throwable t) {
+			event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_OTHER,
+					"Error checking access permissions - please contact a server admin");
+			throw t;
+		}
+	}
+
+	public void tryPlayerJoin(AsyncPlayerPreLoginEvent event) {
+		var uuid = playerMap.getMappedUUID(event.getUniqueId());
 		var offlinePlayer = Bukkit.getOfflinePlayer(uuid);
 
 		if (canPlayerBypass(offlinePlayer)) {

--- a/plugin/src/main/java/io/twitchmc/PlayerListener.java
+++ b/plugin/src/main/java/io/twitchmc/PlayerListener.java
@@ -5,24 +5,27 @@ import io.twitchmc.http.ApiClient;
 import io.twitchmc.util.UserCache;
 import net.milkbowl.vault.permission.Permission;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 
 import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class PlayerListener implements Listener {
 	private final ApiClient apiClient;
 	private final ConfigHolder configHolder;
+	private final Logger logger;
 	private final PlayerMap playerMap;
 	private final UserCache userCache;
 	private Permission permissionApi;
 
-	public PlayerListener(ApiClient apiClient, ConfigHolder configHolder, PlayerMap playerMap) {
+	public PlayerListener(ApiClient apiClient, ConfigHolder configHolder, Logger logger, PlayerMap playerMap) {
 		this.apiClient = apiClient;
 		this.configHolder = configHolder;
+		this.logger = logger;
 		this.playerMap = playerMap;
 		this.userCache = new UserCache();
 
@@ -57,7 +60,7 @@ public class PlayerListener implements Listener {
 			return;
 		}
 
-		Bukkit.getLogger().info("%s%s has joined, checking access".formatted(ChatColor.BLUE, uuid));
+		logger.info("%s has joined, checking access".formatted(uuid));
 
 		boolean isServerVerified = !configHolder.getServerId().isBlank();
 
@@ -88,7 +91,7 @@ public class PlayerListener implements Listener {
 				event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_WHITELIST, message);
 			}
 		} catch (IOException | InterruptedException e) {
-			e.printStackTrace();
+			logger.log(Level.WARNING, "Failed to check access permissions", e);
 
 			event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_OTHER,
 					"There was an error checking your access permissions - please try again later or contact a moderator.");

--- a/plugin/src/main/java/io/twitchmc/PlayerListener.java
+++ b/plugin/src/main/java/io/twitchmc/PlayerListener.java
@@ -82,11 +82,15 @@ public class PlayerListener implements Listener {
 				userCache.cacheUser(uuid);
 				event.allow();
 			} else {
-				var message = result.linked()
-						? "You don't have an active subscription to the streamer that owns this server! Please renew " +
-						"your subscription, or visit https://twitchmc.io if you need to link a different account."
-						: "You need to link your Twitch account in order to play on this server! Please " +
-						"visit https://twitchmc.io/connect and use code: %s".formatted(result.code());
+				var message = result.description();
+				if (message == null) {
+					logger.warning("Missing error message from server for access = false response");
+					message = "Missing error message from server - please report this to TwitchMC";
+				}
+
+				if (result.hasError()) {
+					logger.info("Login for %s failed - %s: %s".formatted(uuid, result.error(), message));
+				}
 
 				event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_WHITELIST, message);
 			}

--- a/plugin/src/main/java/io/twitchmc/TwitchMC.java
+++ b/plugin/src/main/java/io/twitchmc/TwitchMC.java
@@ -2,6 +2,9 @@ package io.twitchmc;
 
 import io.twitchmc.commands.CommandRegister;
 import io.twitchmc.commands.TwitchMCTabCompleter;
+import io.twitchmc.floodgate.FloodgatePlayerLink;
+import io.twitchmc.floodgate.IdentityPlayerMap;
+import io.twitchmc.floodgate.PlayerMap;
 import io.twitchmc.http.ApiClient;
 import io.twitchmc.scheduler.Scheduler;
 import org.bukkit.Bukkit;
@@ -21,7 +24,12 @@ public class TwitchMC extends JavaPlugin {
 		var apiClient = new ApiClient(apiDomain, this.getDescription().getVersion());
 		var scheduler = new Scheduler(this);
 
-		var playerListener = new PlayerListener(apiClient, configHolder);
+		PlayerMap playerMap = new IdentityPlayerMap();
+		if (Bukkit.getPluginManager().isPluginEnabled("floodgate")) {
+			playerMap = new FloodgatePlayerLink(getLogger());
+		}
+
+		var playerListener = new PlayerListener(apiClient, configHolder, playerMap);
 		getServer().getPluginManager().registerEvents(playerListener, this);
 
 		this.getCommand("twitchmc").setTabCompleter(new TwitchMCTabCompleter());

--- a/plugin/src/main/java/io/twitchmc/TwitchMC.java
+++ b/plugin/src/main/java/io/twitchmc/TwitchMC.java
@@ -8,13 +8,12 @@ import io.twitchmc.floodgate.PlayerMap;
 import io.twitchmc.http.ApiClient;
 import io.twitchmc.scheduler.Scheduler;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class TwitchMC extends JavaPlugin {
 	@Override
 	public void onEnable() {
-		Bukkit.getLogger().info(ChatColor.GREEN + "Enabled " + this.getName());
+		getLogger().info("Enabled " + this.getName());
 		saveDefaultConfig();
 
 		var configHolder = new ConfigHolder(this);
@@ -29,17 +28,17 @@ public class TwitchMC extends JavaPlugin {
 			playerMap = new FloodgatePlayerLink(getLogger());
 		}
 
-		var playerListener = new PlayerListener(apiClient, configHolder, playerMap);
+		var playerListener = new PlayerListener(apiClient, configHolder, getLogger(), playerMap);
 		getServer().getPluginManager().registerEvents(playerListener, this);
 
 		this.getCommand("twitchmc").setTabCompleter(new TwitchMCTabCompleter());
-		this.getCommand("twitchmc").setExecutor(new CommandRegister(apiClient, scheduler, configHolder));
+		this.getCommand("twitchmc").setExecutor(new CommandRegister(apiClient, scheduler, configHolder, getLogger()));
 
 		this.getServer().getScheduler().runTaskTimerAsynchronously(this, playerListener::cleanCache, 0L, 6000L);
 	}
 
 	@Override
 	public void onDisable() {
-		Bukkit.getLogger().info(ChatColor.RED + "Disabled " + this.getName());
+		getLogger().info("Disabled " + this.getName());
 	}
 }

--- a/plugin/src/main/java/io/twitchmc/commands/CommandRegister.java
+++ b/plugin/src/main/java/io/twitchmc/commands/CommandRegister.java
@@ -7,20 +7,23 @@ import io.twitchmc.ConfigHolder;
 import io.twitchmc.http.ApiClient;
 import io.twitchmc.model.ServerRegisterResponse;
 import io.twitchmc.scheduler.Scheduler;
-import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+
+import java.util.logging.Logger;
 
 public class CommandRegister implements CommandExecutor {
 	private final ApiClient apiClient;
 	private final Scheduler scheduler;
 	private final ConfigHolder configHolder;
+	private final Logger logger;
 
-	public CommandRegister(ApiClient apiClient, Scheduler scheduler, ConfigHolder configHolder) {
+	public CommandRegister(ApiClient apiClient, Scheduler scheduler, ConfigHolder configHolder, Logger logger) {
 		this.apiClient = apiClient;
 		this.scheduler = scheduler;
 		this.configHolder = configHolder;
+		this.logger = logger;
 	}
 
 	@Override
@@ -64,7 +67,7 @@ public class CommandRegister implements CommandExecutor {
 				if (result.error() != null) {
 					var error = result.error();
 
-					Bukkit.getLogger().warning("Error registering server with TwitchMC, code: %s - description: %s"
+					logger.warning("Error registering server with TwitchMC, code: %s - description: %s"
 							.formatted(error.code(), error.description()));
 
 					sender.sendMessage("Error registering server with TwitchMC - %s".formatted(error.description()));

--- a/plugin/src/main/java/io/twitchmc/floodgate/FloodgatePlayerLink.java
+++ b/plugin/src/main/java/io/twitchmc/floodgate/FloodgatePlayerLink.java
@@ -1,0 +1,51 @@
+package io.twitchmc.floodgate;
+
+import org.geysermc.floodgate.api.FloodgateApi;
+import org.geysermc.floodgate.api.link.PlayerLink;
+
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class FloodgatePlayerLink implements PlayerMap {
+	private final Logger logger;
+	private final FloodgateApi floodgateApi;
+	private final PlayerLink playerLink;
+
+	public FloodgatePlayerLink(Logger logger) {
+		this.logger = logger;
+		this.floodgateApi = FloodgateApi.getInstance();
+		this.playerLink = floodgateApi.getPlayerLink();
+	}
+
+	@Override
+	public UUID getMappedUUID(UUID loginUUID) {
+		// If we're a normal java UUID, continue unchanged
+		// If linking is disabled, continue unchanged
+		if (!floodgateApi.isFloodgateId(loginUUID) || !playerLink.isEnabled()) {
+			return loginUUID;
+		}
+
+		// Else if it's a floodgate UUID, try resolving the link
+		var fut = playerLink.getLinkedPlayer(loginUUID).thenApply(linkedPlayer -> {
+			if (linkedPlayer != null) {
+				logger.info("Found linked player for XUID %s".formatted(linkedPlayer.getBedrockId()));
+				return linkedPlayer.getJavaUniqueId();
+			} else {
+				// No link, just return the floodgate UUID back to be checked against the whitelist
+				logger.fine("No linked player for player %s, checking against Bedrock account".formatted(loginUUID));
+				return loginUUID;
+			}
+		});
+
+		try {
+			return fut.get(10, TimeUnit.SECONDS);
+		} catch (InterruptedException | ExecutionException | TimeoutException e) {
+			logger.log(Level.WARNING, "Failed to resolve linked player", e);
+			throw new RuntimeException("Failed to resolve linked player", e);
+		}
+	}
+}

--- a/plugin/src/main/java/io/twitchmc/floodgate/IdentityPlayerMap.java
+++ b/plugin/src/main/java/io/twitchmc/floodgate/IdentityPlayerMap.java
@@ -1,0 +1,10 @@
+package io.twitchmc.floodgate;
+
+import java.util.UUID;
+
+public class IdentityPlayerMap implements PlayerMap {
+	@Override
+	public UUID getMappedUUID(UUID loginUUID) {
+		return loginUUID;
+	}
+}

--- a/plugin/src/main/java/io/twitchmc/floodgate/PlayerMap.java
+++ b/plugin/src/main/java/io/twitchmc/floodgate/PlayerMap.java
@@ -1,0 +1,7 @@
+package io.twitchmc.floodgate;
+
+import java.util.UUID;
+
+public interface PlayerMap {
+	UUID getMappedUUID(UUID loginUUID);
+}

--- a/plugin/src/main/java/io/twitchmc/model/CheckAccessResponse.java
+++ b/plugin/src/main/java/io/twitchmc/model/CheckAccessResponse.java
@@ -1,3 +1,7 @@
 package io.twitchmc.model;
 
-public record CheckAccessResponse(boolean access, boolean linked, String code) {}
+public record CheckAccessResponse(boolean access, boolean linked, String code, String error, String description) {
+	public boolean hasError() {
+		return this.error != null;
+	}
+}

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -5,6 +5,8 @@ main: io.twitchmc.TwitchMC
 api-version: 1.18
 depend:
   - Vault
+softdepend:
+  - floodgate
 commands:
   twitchmc:
     description: Use various TwitchMC commands


### PR DESCRIPTION
## Changes

- Add Floodgate player mapping support
  - If an incoming Bedrock player has a linked account, use their Java account UUID for access checks.
  - This allows existing Java players to link a Bedrock account using https://link.geysermc.org/ and then play on any platform.
  - Disables itself if Floodgate isn't installed or account linking is disabled in its config file.
- Improve logging: always use the plugin logger & log more messages
- Always use the `description` from the server during /checkAccess
  - Moved the previously plugin-controlled descriptions into the server code
  - Fixes the bug where it tells players to "use code null" if the Twitch token is expired
  - Exposes more error messages to the user, making it clearer what's going wrong

## Fixes

- Fix errors thrown during AsyncPlayerPreLoginEvent potentially causing the whitelist to not be enforced
  - All-exceptions catch handler now disallows login by default